### PR TITLE
Fixup operands pointing to replaced instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.user
 *.sln.docstates
 *.pidb
+*.userprefs
 
 # Build results
 [Dd]ebug/

--- a/AssemblyToProcess/TargetClass.cs
+++ b/AssemblyToProcess/TargetClass.cs
@@ -132,4 +132,11 @@
         return x != y;
     }
 
+    public bool ConditionalBranch()
+    {
+        string x = "foo";
+        string y = "F";
+        string z = "G";
+        return x.StartsWith (y ?? z);
+    }
 }

--- a/Fody/Fody.csproj
+++ b/Fody/Fody.csproj
@@ -107,6 +107,7 @@
     <Compile Include="MsCoreReferenceFinder.cs" />
     <Compile Include="Verifier.cs" />
     <Compile Include="WeavingException.cs" />
+    <Compile Include="ModuleWeaverOperandTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="NugetAssets\Caseless.Fody.nuspec">

--- a/Fody/Fody.csproj
+++ b/Fody/Fody.csproj
@@ -137,7 +137,8 @@
     <MakeDir Directories="$(SolutionDir)NuGetBuild" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\Caseless.Fody.nuspec" DestinationFolder="$(SolutionDir)NuGetBuild" />
     <Copy SourceFiles="$(OutputPath)Caseless.Fody.dll" DestinationFolder="$(SolutionDir)NuGetBuild" />
-    <Copy SourceFiles="$(OutputPath)Caseless.Fody.pdb" DestinationFolder="$(SolutionDir)NuGetBuild" />
+    <Copy SourceFiles="$(OutputPath)Caseless.Fody.pdb" DestinationFolder="$(SolutionDir)NuGetBuild" Condition="Exists('$(OutputPath)Caseless.Fody.pdb')" />
+    <Copy SourceFiles="$(OutputPath)Caseless.Fody.dll.mdb" DestinationFolder="$(SolutionDir)NuGetBuild" Condition="Exists('$(OutputPath)Caseless.Fody.dll.mdb')" />
     <Copy SourceFiles="$(ProjectDir)NuGetAssets\Fody_ToBeDeleted.txt" DestinationFolder="$(SolutionDir)NuGetBuild\Content" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\install.ps" DestinationFiles="$(SolutionDir)NuGetBuild\Tools\install.ps1" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\uninstall.ps" DestinationFiles="$(SolutionDir)NuGetBuild\Tools\uninstall.ps1" />

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -93,6 +93,10 @@ public class ModuleWeaver
                 var replaceWith = converter.Convert(methodReference).ToList();
                 if (replaceWith.Count > 0)
                 {
+                    foreach (var inst in instructions.Where(i => i.Operand == instruction))
+                    {
+                        inst.Operand = replaceWith[0];
+                    }
                     instructions.RemoveAt(index);
                     foreach (var innerInstruction in replaceWith)
                     {

--- a/Fody/ModuleWeaverOperandTests.cs
+++ b/Fody/ModuleWeaverOperandTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using NUnit.Framework;
+
+[TestFixture]
+public class ModuleWeaverOperandTests
+{
+    dynamic targetClass;
+
+    public ModuleWeaverOperandTests()
+    {
+        var beforeAssemblyPath = "AssemblyToProcess.dll";
+        var afterAssemblyPath = typeof(ModuleWeaverOperandTests).Name + ".dll";
+
+        var moduleDefinition = ModuleDefinition.ReadModule(beforeAssemblyPath);
+        AddConditionalBranchLong(moduleDefinition, moduleDefinition.Types.Single(t => t.Name == "TargetClass"));
+
+        // Offset assignment happens on write
+        // Having offsets assigned prior to weaving makes tracking down bugs easier
+        moduleDefinition.Write(afterAssemblyPath);
+
+        var weavingTask = new ModuleWeaver
+            {
+                ModuleDefinition = moduleDefinition,
+            };
+        weavingTask.Execute();
+
+        moduleDefinition.Assembly.Name.Name += "ForOperand";
+        moduleDefinition.Write(afterAssemblyPath);
+        var assembly = Assembly.LoadFrom(afterAssemblyPath);
+        var type = assembly.GetType("TargetClass", true);
+        targetClass = Activator.CreateInstance(type);
+    }
+
+    private static void AddConditionalBranchLong(ModuleDefinition module, TypeDefinition type)
+    {
+        var method = new MethodDefinition("ConditionalBranchLong", Mono.Cecil.MethodAttributes.Public, module.TypeSystem.Boolean);
+        var body = method.Body;
+        body.InitLocals = true;
+        var il = body.GetILProcessor();
+
+        // This is the key: a call which will be replaced, targeted by a branch
+        var call = il.Create(OpCodes.Callvirt, module.ImportReference(typeof(String).GetMethod("StartsWith", new[] { typeof(string) })));
+        var branch = il.Create(OpCodes.Brtrue, call);
+
+        il.Append(il.Create(OpCodes.Ldstr, "foo"));
+        il.Append(il.Create(OpCodes.Ldstr, "F"));
+        il.Append(il.Create(OpCodes.Dup));
+        il.Append(branch);
+        il.Append(il.Create(OpCodes.Pop));
+        il.Append(il.Create(OpCodes.Ldstr, "G"));
+        il.Append(call);
+        il.Append(il.Create(OpCodes.Ret));
+
+		type.Methods.Add(method);
+	}
+
+	[Test]
+	public void Conditional()
+	{
+		Assert.IsTrue(targetClass.ConditionalBranchLong());
+	}
+}

--- a/Fody/ModuleWeaverOperatorTests.cs
+++ b/Fody/ModuleWeaverOperatorTests.cs
@@ -14,7 +14,7 @@ public class ModuleWeaverOperatorTests
 
     public ModuleWeaverOperatorTests()
     {
-        beforeAssemblyPath = Path.GetFullPath(@"..\..\..\AssemblyToProcess\bin\Debug\AssemblyToProcess.dll");
+        beforeAssemblyPath = Path.GetFullPath(Path.Combine("..", "..", "..", "AssemblyToProcess", "bin", "Debug", "AssemblyToProcess.dll"));
 #if (!DEBUG)
        beforeAssemblyPath = beforeAssemblyPath.Replace("Debug", "Release");
 #endif

--- a/Fody/ModuleWeaverOrdinalTests.cs
+++ b/Fody/ModuleWeaverOrdinalTests.cs
@@ -14,7 +14,7 @@ public class ModuleWeaverOrdinalTests
 
     public ModuleWeaverOrdinalTests()
     {
-        beforeAssemblyPath = Path.GetFullPath(@"..\..\..\AssemblyToProcess\bin\Debug\AssemblyToProcess.dll");
+        beforeAssemblyPath = Path.GetFullPath(Path.Combine("..", "..", "..", "AssemblyToProcess", "bin", "Debug", "AssemblyToProcess.dll"));
 #if (!DEBUG)
         beforeAssemblyPath = beforeAssemblyPath.Replace("Debug", "Release");
 #endif

--- a/Fody/ModuleWeaverTests.cs
+++ b/Fody/ModuleWeaverTests.cs
@@ -13,7 +13,7 @@ public class ModuleWeaverTests
 
     public ModuleWeaverTests()
     {
-        beforeAssemblyPath = Path.GetFullPath(@"..\..\..\AssemblyToProcess\bin\Debug\AssemblyToProcess.dll");
+        beforeAssemblyPath = Path.GetFullPath(Path.Combine("..", "..", "..", "AssemblyToProcess", "bin", "Debug", "AssemblyToProcess.dll"));
 #if (!DEBUG)
        beforeAssemblyPath = beforeAssemblyPath.Replace("Debug", "Release");
 #endif

--- a/Fody/ModuleWeaverTests.cs
+++ b/Fody/ModuleWeaverTests.cs
@@ -144,6 +144,11 @@ public class ModuleWeaverTests
         Assert.IsFalse(targetClass.EqualsStaticWithNull());
     }
 
+    [Test]
+    public void Conditional()
+    {
+        Assert.IsTrue(targetClass.ConditionalBranch());
+    }
 
 #if(DEBUG)
     [Test]

--- a/Fody/MsCoreReferenceFinder.cs
+++ b/Fody/MsCoreReferenceFinder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Mono.Cecil;
@@ -12,12 +13,14 @@ public class MsCoreReferenceFinder
     {
         var coreTypes = new List<TypeDefinition>();
         AppendTypes("mscorlib", coreTypes);
-        AppendTypes("System.Runtime", coreTypes);
+        if (null == Type.GetType("Mono.Runtime"))
+        {
+            AppendTypes("System.Runtime", coreTypes);
+        }
 
         StringDefinition = coreTypes.First(x => x.Name == "String");
         StringComparisonDefinition = coreTypes.First(x => x.Name == "StringComparison");
     }
-
 
     void AppendTypes(string name, List<TypeDefinition> coreTypes)
     {


### PR DESCRIPTION
Fixes #6 by fixing up operands which point to replaced instructions to point to the new instructions instead.

Two tests are included. One is in ModuleWeaverTests and is similar to the existing tests. However, it only reproduces the problem when the corresponding ConditionalBranch method is generated with long-form branch instructions, which is not guaranteed to happen. Currently it happens on Mono, but not on .NET.

Another test is included in a new test class, ModuleWeaverOperandTests. Instead of using code to generate the test methods, a test method is created with IL, with the problematic pattern included. This ensures that the test is valid on all platforms.